### PR TITLE
aes256 secret decoder provider

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
+++ b/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
@@ -1,3 +1,4 @@
 io.lenses.connect.secrets.providers.AzureSecretProvider
 io.lenses.connect.secrets.providers.VaultSecretProvider
 io.lenses.connect.secrets.providers.AWSSecretProvider
+io.lenses.connect.secrets.providers.Aes256DecodingProvider

--- a/src/main/scala/io/lenses/connect/secrets/config/Aes256DecodingProviderConfig.scala
+++ b/src/main/scala/io/lenses/connect/secrets/config/Aes256DecodingProviderConfig.scala
@@ -1,0 +1,22 @@
+package io.lenses.connect.secrets.config
+
+import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
+import org.apache.kafka.common.config.ConfigDef.{Importance, Type}
+import java.util
+
+object Aes256ProviderConfig {
+  val SECRET_KEY = "aes256.key"
+  
+  val config = new ConfigDef().define(
+    SECRET_KEY,
+    Type.STRING,
+    "",
+    Importance.MEDIUM,
+    "Key used to decode AES256 encoded values"
+  )
+}
+
+case class Aes256ProviderConfig(props: util.Map[String, _])
+ extends AbstractConfig(Aes256ProviderConfig.config, props) {
+   def aes256Key: String = getString(Aes256ProviderConfig.SECRET_KEY)
+ }

--- a/src/main/scala/io/lenses/connect/secrets/providers/Aes256DecodingHelper.scala
+++ b/src/main/scala/io/lenses/connect/secrets/providers/Aes256DecodingHelper.scala
@@ -1,0 +1,107 @@
+package io.lenses.connect.secrets.providers
+
+import javax.crypto.Cipher
+import javax.crypto.SecretKey
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+import scala.util.Try
+
+import java.security.SecureRandom
+import java.util.Base64
+import scala.util.Failure
+import scala.util.Success
+
+private[providers] object Aes256DecodingHelper {
+
+  /** characters used to separate initialisation vector from encoded text */
+  val INITIALISATION_VECTOR_SEPARATOR = " "
+
+  private val BYTES_AMOUNT = 32
+  private val CHARSET = "UTF-8"
+
+  /**
+    * Initializes AES256 decoder for valid key or fails for invalid key
+    *
+    * @param key key of 32 bytes
+    * @return AES256 decoder
+    */
+  def init(key: String): Either[String, Aes256DecodingHelper] =
+    key.getBytes(CHARSET).length match {
+      case BYTES_AMOUNT =>
+        Right(new Aes256DecodingHelper(key, INITIALISATION_VECTOR_SEPARATOR))
+      case n =>
+        Left(s"Invalid secret key length ($n - required $BYTES_AMOUNT bytes)")
+    }
+}
+
+private[providers] class Aes256DecodingHelper private (
+    key: String,
+    ivSeparator: String
+) {
+  import B64._
+  import Aes256DecodingHelper.CHARSET
+  import InitializationVector._
+  private val secret = new SecretKeySpec(key.getBytes(CHARSET), "AES")
+
+  def decrypt(s: String): Try[String] =
+    for {
+      (iv, encoded) <- InitializationVector.extractInitialisationVector(s, ivSeparator)
+      decoded <- base64Decode(encoded)
+      decrypted <- decryptBytes(iv, decoded)
+    } yield new String(decrypted, CHARSET)
+
+  private def decryptBytes(
+      iv: InitializationVector,
+      bytes: Array[Byte]
+  ): Try[Array[Byte]] =
+    for {
+      cipher <- getCipher(Cipher.DECRYPT_MODE, iv)
+      encrypted <- Try(cipher.doFinal(bytes))
+    } yield encrypted
+
+  private def getCipher(mode: Int, iv: InitializationVector): Try[Cipher] =
+    Try {
+      val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      val ivSpec = new IvParameterSpec(iv.bytes)
+      cipher.init(mode, secret, ivSpec)
+      cipher
+    }
+}
+
+private case class InitializationVector private (bytes: Array[Byte])
+
+private object InitializationVector {
+  import B64._
+  private val random = new SecureRandom()
+  private val length = 16
+
+  def apply(): InitializationVector = {
+    val bytes = Array.fill[Byte](length)(0.byteValue)
+    random.nextBytes(bytes)
+
+    new InitializationVector(bytes)
+  }
+
+  def extractInitialisationVector(
+      s: String,
+      ivSeparator: String
+  ): Try[(InitializationVector, String)] =
+    s.indexOf(ivSeparator) match {
+      case -1 =>
+        Failure(
+          new IllegalStateException(
+            "Invalid format: missing initialization vector"
+          )
+        )
+      case i =>
+        base64Decode(s.substring(0, i)).map(b =>
+          (new InitializationVector(b), s.substring(i + 1))
+        )
+    }
+}
+
+private object B64 {
+  def base64Decode(s: String): Try[Array[Byte]] =
+    Try(Base64.getDecoder().decode(s))
+}

--- a/src/main/scala/io/lenses/connect/secrets/providers/Aes256DecodingProvider.scala
+++ b/src/main/scala/io/lenses/connect/secrets/providers/Aes256DecodingProvider.scala
@@ -1,0 +1,40 @@
+package io.lenses.connect.secrets.providers
+
+import org.apache.kafka.common.config.ConfigData
+import org.apache.kafka.common.config.provider.ConfigProvider
+import org.apache.kafka.connect.errors.ConnectException
+import org.apache.kafka.common.config.ConfigException
+import java.util
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+import io.lenses.connect.secrets.config.Aes256ProviderConfig
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+class Aes256DecodingProvider extends ConfigProvider {
+
+  var decoder: Option[Aes256DecodingHelper] = None
+  
+  override def configure(configs: util.Map[String, _]): Unit = {
+    val aes256Key = Aes256ProviderConfig(configs).aes256Key
+    decoder = Option(aes256Key)
+      .map(Aes256DecodingHelper.init)
+      .map(_.fold(e => throw new ConfigException(e), identity))
+  }
+
+  override def get(path: String): ConfigData = new ConfigData(Map.empty[String, String].asJava)
+  
+  override def get(path: String, keys: util.Set[String]): ConfigData =
+    decoder match {
+      case Some(d) =>
+        def decrypt(key: String) =
+          d.decrypt(key).fold(e => throw new ConnectException(e.getMessage(), e), identity)
+        new ConfigData(keys.asScala.map(k => k -> decrypt(k)).toMap.asJava)
+      case None =>
+        throw new ConnectException("decoder is not configured.")
+    }
+
+  override def close(): Unit = {}
+}

--- a/src/test/scala/io/lenses/connect/secrets/providers/Aes256DecodingHelperTest.scala
+++ b/src/test/scala/io/lenses/connect/secrets/providers/Aes256DecodingHelperTest.scala
@@ -1,0 +1,77 @@
+package io.lenses.connect.secrets.providers
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.prop.TableDrivenPropertyChecks
+import scala.util.Random.nextString
+import scala.util.Try
+import Aes256DecodingHelper.INITIALISATION_VECTOR_SEPARATOR
+import scala.util.Success
+import java.util.UUID.randomUUID
+
+class Aes256DecodingHelperTest
+    extends AnyWordSpec
+    with Matchers
+    with TableDrivenPropertyChecks {
+      
+  import AesDecodingTestHelper.encrypt    
+
+  "AES-256 decorer" should {
+    "not be created for invalid key length" in {
+      val secretKey = randomUUID.toString.take(16)
+      Aes256DecodingHelper.init(secretKey) shouldBe 'left
+    }
+
+    "not be able to decrypt message for uncrecognized key" in new TestContext {
+      forAll(inputs) { text =>
+        val otherAes256 = newEncryption(key)
+
+        val encrypted = encrypt(text, generateKey())
+
+        otherAes256.decrypt(encrypted) should not be text
+      }
+    }
+
+    "decrypt encrypted text" in new TestContext {
+      forAll(inputs) { text: String =>
+        val aes256 = newEncryption(key)
+        val encrypted = encrypt(text, key)
+
+        aes256.decrypt(encrypted) shouldBe Success(text)
+      }
+    }
+
+    "decrypt same text prefixed with different initialization vector" in new TestContext {
+      forAll(inputs) { text: String =>
+        val aes256 = newEncryption(key)
+        val encrypted1 = encrypt(text, key)
+        val encrypted2 = encrypt(text, key)
+        removePrefix(encrypted1) should not be removePrefix(encrypted2)
+
+        aes256.decrypt(encrypted1) shouldBe aes256.decrypt(encrypted2)
+      }
+    }
+  }
+
+  trait TestContext {
+    val key = generateKey() 
+
+    def generateKey(): String = randomUUID.toString.take(32)
+
+    val inputs = Table(
+      "string to decode",
+      "",
+      nextString(length = 1),
+      nextString(length = 10),
+      nextString(length = 100),
+      nextString(length = 1000),
+      nextString(length = 10000)
+    )
+
+    def removePrefix(s: String) =
+      s.split(INITIALISATION_VECTOR_SEPARATOR).tail.head
+
+    def newEncryption(k: String) =
+      Aes256DecodingHelper.init(k).fold(m => throw new Exception(m), identity)
+  }
+}

--- a/src/test/scala/io/lenses/connect/secrets/providers/Aes256DecodingProviderTest.scala
+++ b/src/test/scala/io/lenses/connect/secrets/providers/Aes256DecodingProviderTest.scala
@@ -1,0 +1,67 @@
+package io.lenses.connect.secrets.providers
+
+import org.apache.kafka.common.config.provider.ConfigProvider
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import java.util.UUID.randomUUID
+import io.lenses.connect.secrets.config.Aes256ProviderConfig
+import scala.collection.JavaConverters._
+import org.apache.kafka.connect.errors.ConnectException
+import org.apache.kafka.common.config.ConfigException
+import org.apache.kafka.common.config.ConfigTransformer
+
+class Aes256DecodingProviderTest extends AnyWordSpec with Matchers {
+  import AesDecodingTestHelper.encrypt
+
+  "aes256 provider" should {
+    "decode aes 256 encoded value" in new TestContext {
+      val value = "hello!!"
+      val encrypted = encrypt(value, key)
+      provider.configure(config)
+
+      val decrypted = provider.get("", Set(encrypted).asJava).data().asScala
+      
+      decrypted.get(encrypted) shouldBe Some(value)
+    }
+
+    "fail decoding when unable to decode" in new TestContext {
+      provider.configure(config)
+      
+      assertThrows[ConnectException] {
+        provider.get("", Set("abc").asJava)
+      }
+    }
+
+    "fail decoding when not configured" in new TestContext {
+      assertThrows[ConnectException] {
+        provider.get("", Set(encrypt("hi!", key)).asJava)
+      }
+    }
+
+    "fail to configure with invalid key" in new TestContext {
+      assertThrows[ConfigException] {
+        provider.configure(Map(Aes256ProviderConfig.SECRET_KEY -> "too-short").asJava)
+      }
+    }
+
+    "transform value referencin to the provider" in new TestContext {
+      val value = "hi!"
+      val encrypted = encrypt(value, key)
+      provider.configure(config)
+
+      val transformer = new ConfigTransformer(Map[String, ConfigProvider]("aes256" -> provider).asJava)
+      val props = Map("mykey" -> ("$" + s"{aes256::$encrypted}")).asJava
+      val data = transformer.transform(props)
+      data.data().containsKey(encrypted)
+      data.data().get("mykey") shouldBe value
+    }
+  }
+  
+  trait TestContext {
+    val key = randomUUID.toString.take(32)
+    val provider = new Aes256DecodingProvider()
+    val config = Map(
+      Aes256ProviderConfig.SECRET_KEY -> key
+    ).asJava
+  }
+}

--- a/src/test/scala/io/lenses/connect/secrets/providers/AesDecodingTestHelper.scala
+++ b/src/test/scala/io/lenses/connect/secrets/providers/AesDecodingTestHelper.scala
@@ -1,0 +1,41 @@
+package io.lenses.connect.secrets.providers
+
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import java.util.Base64
+import scala.util.Try
+import Aes256DecodingHelper.INITIALISATION_VECTOR_SEPARATOR
+
+object AesDecodingTestHelper {
+  private val AES = "AES"
+    
+    def encrypt(s: String, key: String): String = {
+      val iv = InitializationVector()
+      encryptBytes(s.getBytes("UTF-8"), iv, key).map(encrypted =>
+        base64Encode(iv.bytes) + INITIALISATION_VECTOR_SEPARATOR + base64Encode(encrypted)
+      ).get
+    }
+
+    private def encryptBytes(
+        bytes: Array[Byte],
+        iv: InitializationVector,
+        key: String
+    ): Try[Array[Byte]] =
+      for {
+        cipher <- getCipher(Cipher.ENCRYPT_MODE, iv, key)
+        encrypted <- Try(cipher.doFinal(bytes))
+      } yield encrypted
+
+    private def getCipher(mode: Int, iv: InitializationVector, key: String): Try[Cipher] =
+      Try {
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        val ivSpec = new IvParameterSpec(iv.bytes)
+        val secret = new SecretKeySpec(key.getBytes("UTF-8"), AES)
+        cipher.init(mode, secret, ivSpec)
+        cipher
+      }
+
+    private def base64Encode(bytes: Array[Byte]) =
+      Base64.getEncoder().encodeToString(bytes)
+}


### PR DESCRIPTION
This PR adds new type of KC provider: provider that gets AES256 encoded value as a key and (instead of looking up for the value) decodes it to get the value.

So e.g. if aes256 encoded "hello" equaled to "xyxyxy" - then if I configure connector to use `{aes256::$xyxyxy}` for a parameter value, the value should be substituted with "hello" string.

The provider requires aes256 secret key as a configuration parameter, the key needs to have proper length (32 bytes).