### PR TITLE
generating uuid file names for eas256 encoded files

### DIFF
--- a/src/main/scala/io/lenses/connect/secrets/providers/Aes256DecodingProvider.scala
+++ b/src/main/scala/io/lenses/connect/secrets/providers/Aes256DecodingProvider.scala
@@ -15,6 +15,7 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 import io.lenses.connect.secrets.connect.Encoding
 import java.nio.file.FileSystems
+import java.util.UUID.randomUUID
 
 class Aes256DecodingProvider extends ConfigProvider {
 
@@ -41,7 +42,7 @@ class Aes256DecodingProvider extends ConfigProvider {
           decodeKey(
             key = keyPrefixedWithEncoding,
             value = decrypted,
-            fileName = getFileName(writeDir, "secrets", key.toLowerCase, FileSystems.getDefault.getSeparator)
+            fileName = getFileName(writeDir, "secrets", randomUUID().toString, FileSystems.getDefault.getSeparator)
           )
         }
           

--- a/src/test/scala/io/lenses/connect/secrets/providers/Aes256DecodingProviderTest.scala
+++ b/src/test/scala/io/lenses/connect/secrets/providers/Aes256DecodingProviderTest.scala
@@ -30,8 +30,7 @@ class Aes256DecodingProviderTest
       val encrypted = encrypt(value, key)
 
       forAll(Table("encoding", "", "utf-8")) { encoding =>
-        val decrypted =
-          provider.get(encoding, Set(encrypted).asJava).data().asScala
+        val decrypted = provider.get(encoding, Set(encrypted).asJava).data().asScala
 
         decrypted.get(encrypted) shouldBe Some(value)
       }
@@ -45,19 +44,18 @@ class Aes256DecodingProviderTest
       decrypted.get(encrypted) shouldBe Some(value)
     }
 
-    "decrypt aes 256 encoded value stored in file with utf-8 encoding" in new TestContext
-      with ConfiguredProvider {
+    "decrypt aes 256 encoded value stored in file with utf-8 encoding" in new TestContext with ConfiguredProvider {
       val encrypted = encrypt(value, key)
 
       val providerData = provider.get("utf8_file", Set(encrypted).asJava).data().asScala
       val decryptedPath = providerData.get(encrypted).get
 
-      decryptedPath should startWith(s"$tmpDir/")
+      decryptedPath should startWith(s"$tmpDir/secrets/")
+      decryptedPath.toLowerCase.contains(encrypted.toLowerCase) shouldBe false
       Source.fromFile(decryptedPath).getLines.mkString shouldBe value
     }
 
-    "decrypt aes 256 encoded value stored in file with base64 encoding" in new TestContext
-      with ConfiguredProvider {
+    "decrypt aes 256 encoded value stored in file with base64 encoding" in new TestContext with ConfiguredProvider {
       val bytesAmount = 100
       val bytesInput = Array.fill[Byte](bytesAmount)(0)
       Random.nextBytes(bytesInput)
@@ -66,7 +64,8 @@ class Aes256DecodingProviderTest
       val providerData = provider.get("base64_file", Set(encrypted).asJava).data().asScala
       val decryptedPath = providerData.get(encrypted).get
 
-      decryptedPath should startWith(s"$tmpDir/")
+      decryptedPath should startWith(s"$tmpDir/secrets/")
+      decryptedPath.toLowerCase.contains(encrypted.toLowerCase) shouldBe false
       val bytesConsumed = Array.fill[Byte](bytesAmount)(0)
       new FileInputStream(decryptedPath).read(bytesConsumed)
 
@@ -81,8 +80,7 @@ class Aes256DecodingProviderTest
       val transformer = new ConfigTransformer(
         Map[String, ConfigProvider]("aes256" -> provider).asJava
       )
-      val props =
-        Map("mykey" -> ("$" + s"{aes256::$encrypted}")).asJava
+      val props = Map("mykey" -> ("$" + s"{aes256::$encrypted}")).asJava
       val data = transformer.transform(props)
       data.data().containsKey(encrypted)
       data.data().get("mykey") shouldBe value


### PR DESCRIPTION
created file name will be generated uuid
we should not use the reference key to generate the file name, because it is encrypted file content (and may be possibly large)