### PR TITLE
Vault provider

### DIFF
--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/Aes256ProviderConfig.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/Aes256ProviderConfig.scala
@@ -30,6 +30,6 @@ object Aes256ProviderConfig {
 }
 
 case class Aes256ProviderConfig(props: util.Map[String, _]) extends AbstractConfig(Aes256ProviderConfig.config, props) {
-  def aes256Key:      String = getPassword(Aes256ProviderConfig.SECRET_KEY).value()
-  def writeDirectory: String = getString(FILE_DIR)
+  def aes256Key:         String            = getPassword(Aes256ProviderConfig.SECRET_KEY).value()
+  def fileWriterOptions: FileWriterOptions = FileWriterOptions(getString(FILE_DIR))
 }

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/FileWriterOptions.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/FileWriterOptions.scala
@@ -1,0 +1,23 @@
+package io.lenses.connect.secrets.config
+
+import io.lenses.connect.secrets.connect.FILE_DIR
+import io.lenses.connect.secrets.connect.WRITE_FILES
+import io.lenses.connect.secrets.io.FileWriterOnce
+import org.apache.kafka.common.config.AbstractConfig
+
+import java.nio.file.Paths
+
+object FileWriterOptions {
+  def apply(config: AbstractConfig): Option[FileWriterOptions] =
+    Option.when(config.getBoolean(WRITE_FILES)) {
+      FileWriterOptions(config.getString(FILE_DIR))
+    }
+}
+
+case class FileWriterOptions(
+  fileDir: String,
+) {
+  def createFileWriter(): FileWriterOnce =
+    new FileWriterOnce(Paths.get(fileDir, "secrets"))
+
+}

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/VaultProviderSettings.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/VaultProviderSettings.scala
@@ -11,12 +11,9 @@ import io.lenses.connect.secrets.config.AbstractConfigExtensions._
 import io.lenses.connect.secrets.config.VaultAuthMethod.VaultAuthMethod
 import io.lenses.connect.secrets.config.VaultProviderConfig.TOKEN_RENEWAL
 import io.lenses.connect.secrets.connect._
-import io.lenses.connect.secrets.io.FileWriterOnce
-import org.apache.kafka.common.config.AbstractConfig
 import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.connect.errors.ConnectException
 
-import java.nio.file.Paths
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import scala.concurrent.duration.DurationInt
@@ -41,21 +38,6 @@ case class AppRole(role: String, secretId: Password)
 case class K8s(role: String, jwt: Password)
 case class Cert(mount: String)
 case class Github(token: Password, mount: String)
-
-object FileWriterOptions {
-  def apply(config: AbstractConfig): Option[FileWriterOptions] =
-    Option.when(config.getBoolean(WRITE_FILES)) {
-      FileWriterOptions(config.getString(FILE_DIR))
-    }
-}
-
-case class FileWriterOptions(
-  fileDir: String,
-) {
-  def createFileWriter(path: String): FileWriterOnce =
-    new FileWriterOnce(Paths.get(fileDir, path))
-
-}
 
 case class VaultSettings(
   addr:           String,

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSSecretProvider.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSSecretProvider.scala
@@ -30,7 +30,7 @@ class AWSSecretProvider(testClient: Option[SecretsManagerClient]) extends Config
     val awsClient = testClient.getOrElse(createClient(settings))
     val helper = new AWSHelper(awsClient,
                                settings.defaultTtl,
-                               fileWriterCreateFn = path => settings.fileWriterOpts.map(_.createFileWriter(path)),
+                               fileWriterCreateFn = () => settings.fileWriterOpts.map(_.createFileWriter()),
     )
     secretProvider = Some(
       new SecretProvider(

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/VaultSecretProvider.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/VaultSecretProvider.scala
@@ -35,7 +35,7 @@ class VaultSecretProvider() extends ConfigProvider {
     val helper = new VaultHelper(
       vaultClient,
       settings.defaultTtl,
-      fileWriterCreateFn = path => settings.fileWriterOpts.map(_.createFileWriter(path)),
+      fileWriterCreateFn = () => settings.fileWriterOpts.map(_.createFileWriter()),
     )
 
     secretProvider   = Some(new SecretProvider(getClass.getSimpleName, helper.lookup))

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/AWSSecretProviderTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/AWSSecretProviderTest.scala
@@ -185,7 +185,7 @@ class AWSSecretProviderTest extends AnyWordSpec with Matchers with MockitoSugar 
 
     val data       = provider.get(secretName, Set(secretKey).asJava)
     val outputFile = data.data().get(secretKey)
-    outputFile shouldBe s"$tmp$separator$secretName$separator${secretKey.toLowerCase}"
+    outputFile shouldBe s"$tmp${separator}secrets$separator${secretKey.toLowerCase}"
 
     Using(Source.fromFile(outputFile))(_.getLines().mkString) shouldBe Success(
       secretValue,
@@ -240,7 +240,7 @@ class AWSSecretProviderTest extends AnyWordSpec with Matchers with MockitoSugar 
 
     val data       = provider.get(secretName, Set(secretKey).asJava)
     val outputFile = data.data().get(secretKey)
-    outputFile shouldBe s"$tmp$separator$secretName$separator${secretKey.toLowerCase}"
+    outputFile shouldBe s"$tmp${separator}secrets$separator${secretKey.toLowerCase}"
 
     Using(Source.fromFile(outputFile))(_.getLines().mkString) shouldBe Success(
       secretValue,

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/VaultSecretProviderTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/VaultSecretProviderTest.scala
@@ -363,7 +363,7 @@ class VaultSecretProviderTest extends AnyWordSpec with Matchers with BeforeAndAf
       .data()
       .get(secretKey)
 
-    outputFile shouldBe s"$tmp$separator$secretPath$separator$secretKey"
+    outputFile shouldBe s"$tmp${separator}secrets$separator$secretKey"
     Using(Source.fromFile(outputFile))(_.getLines().mkString) shouldBe Success(
       secretValue,
     )
@@ -394,7 +394,7 @@ class VaultSecretProviderTest extends AnyWordSpec with Matchers with BeforeAndAf
       .data()
       .get(secretKey)
 
-    outputFile shouldBe s"$tmp$separator$secretPath$separator$secretKey"
+    outputFile shouldBe s"$tmp${separator}secrets$separator$secretKey"
     Using(Source.fromFile(outputFile))(_.getLines().mkString) shouldBe Success(
       secretValue,
     )


### PR DESCRIPTION
A regression was introduced with the caching layer for the locally stored file. The code is changing the initialization for FileWriterOnce to only use the settings directory as opposed to the folder + vault path.