### PR TITLE
AWS - Add support for AWS SecretsManager non key value pair secrets

### DIFF
--- a/src/main/scala/io/lenses/connect/secrets/providers/AWSHelper.scala
+++ b/src/main/scala/io/lenses/connect/secrets/providers/AWSHelper.scala
@@ -98,8 +98,10 @@ trait AWSHelper extends StrictLogging {
       client.getSecretValue(new GetSecretValueRequest().withSecretId(secretId))
     ) match {
       case Success(secret) =>
-        val value =
-          new ObjectMapper()
+        if(key.trim().isEmpty()) {
+          (secret.getSecretString, getTTL(client, secretId))
+        }else {
+          val value = new ObjectMapper()
             .readValue(
               secret.getSecretString,
               classOf[java.util.HashMap[String, String]]
@@ -126,6 +128,7 @@ trait AWSHelper extends StrictLogging {
           ),
           getTTL(client, secretId)
         )
+      }
 
       case Failure(exception) =>
         throw new ConnectException(

--- a/src/test/scala/io/lenses/connect/secrets/providers/AWSSecretProviderTest.scala
+++ b/src/test/scala/io/lenses/connect/secrets/providers/AWSSecretProviderTest.scala
@@ -96,6 +96,48 @@ class AWSSecretProviderTest
     provider.close()
   }
 
+"should authenticate with credentials and lookup a secret without a key" in {
+    val props = Map(
+      AWSProviderConfig.AUTH_METHOD -> AuthMode.CREDENTIALS.toString,
+      AWSProviderConfig.AWS_ACCESS_KEY -> "somekey",
+      AWSProviderConfig.AWS_SECRET_KEY -> "secretkey",
+      AWSProviderConfig.AWS_REGION -> "someregion"
+    ).asJava
+
+    val secretName = "my-secret-name"
+    val secretValue = "secret-value"
+
+    val provider = new AWSSecretProvider()
+    provider.configure(props)
+
+    val mockClient = mock[AWSSecretsManager]
+    val secretValRequest =
+      new GetSecretValueRequest().withSecretId(secretName)
+    val secretValResponse = new GetSecretValueResult()
+    secretValResponse.setName(secretName)
+    secretValResponse.setSecretString(secretValue)
+
+    val now = new Date()
+    val describeSecretResponse = new DescribeSecretResult()
+    describeSecretResponse.setLastRotatedDate(now)
+    describeSecretResponse.setRotationEnabled(true)
+    describeSecretResponse.setLastRotatedDate(now)
+
+    val rotationRulesType = new RotationRulesType()
+    rotationRulesType.setAutomaticallyAfterDays(1.toLong)
+    describeSecretResponse.setRotationRules(rotationRulesType)
+
+    when(mockClient.describeSecret(any[DescribeSecretRequest]))
+      .thenReturn(describeSecretResponse)
+    when(mockClient.getSecretValue(secretValRequest))
+      .thenReturn(secretValResponse)
+
+    provider.client = Some(mockClient)
+    val data = provider.get(secretName, Set("").asJava)
+    data.data().get("") shouldBe secretValue
+    provider.close()
+  }  
+
   "should authenticate with credentials and lookup a base64 secret" in {
     val props = Map(
       AWSProviderConfig.AUTH_METHOD -> AuthMode.CREDENTIALS.toString,
@@ -141,7 +183,6 @@ class AWSSecretProviderTest
     val data = provider.get(secretName, Set(secretKey).asJava)
     data.data().get(secretKey) shouldBe secretValue
 
-    provider.get("").data().isEmpty shouldBe true
     provider.close()
   }
 
@@ -196,7 +237,6 @@ class AWSSecretProviderTest
     result.getLines().mkString shouldBe secretValue
     result.close()
 
-    provider.get("").data().isEmpty shouldBe true
     provider.close()
   }
 
@@ -252,7 +292,6 @@ class AWSSecretProviderTest
     result.getLines().mkString shouldBe secretValue
     result.close()
 
-    provider.get("").data().isEmpty shouldBe true
     provider.close()
   }
 


### PR DESCRIPTION
# Summary

Adds support for pulling secrets that aren't stored as key value pairs, which is useful if you organize secrets as one secret per path. To use you just omit the key
```
${aws:production/some_service/database/password:}
```
and the secret-provider returns the full string contents of the secret stored at the path.

# Tests

I added a unit test to verify this works, and have also tested in a local Kafka Connect cluster pulling a real secret from AWS SecretsManager.