### PR TITLE
AWS - Add AWS sts dependency so web identity tokens work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ allprojects {
         compile "com.azure:azure-security-keyvault-secrets:${azureKeyVaultVersion}"
         compile "com.azure:azure-identity:${azureIdentityVersion}"
         compile "com.amazonaws:aws-java-sdk-secretsmanager:${awsSecretsVersion}"
+        compile "com.amazonaws:aws-java-sdk-sts:${awsSecretsVersion}"
 
         testImplementation "org.mockito:mockito-scala_${scalaMajorVersion}:${mockitoVersion}"
         testImplementation "org.scalacheck:scalacheck_${scalaMajorVersion}:${scalaCheck}"


### PR DESCRIPTION
# Summary

Adds `aws-java-sdk-sts` dependency so the `WebIdentityTokenCredentialsProvider` works within the `DefaultAWSCredentialsProviderChain`. Without this dependency I was unable to use web identity token files in AWS EKS, see https://github.com/aws/aws-sdk-java-v2/issues/1470#issuecomment-601131243 for more details