### PR TITLE
Azure - Kafka Connect plugin isolation mechanism support for Azure Keyvault secret provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,8 @@ allprojects {
         scalaLoggingVersion = "3.9.2"
         kafkaVersion = "2.5.0"
         vaultVersion = "5.1.0"
-        azureVersion = "1.22.0"
-        azureKeyVaultVersion = "4.1.1"
-        azureIdentityVersion = "1.0.5"
+        azureKeyVaultVersion = "4.3.0"
+        azureIdentityVersion = "1.3.1"
         awsSecretsVersion = "1.11.762"
 
         //test


### PR DESCRIPTION
At the moment its not possible to use the plugin isolation (_plugin.path_) mechanism that Kafka Connect provides. As you wrote in your [documentation of the Azure Keyvault secrets provider](https://docs.lenses.io/4.2/integrations/connectors/secret-providers/azure/) the Azure SDK uses the default classloader and will not find the HTTP client.

The advantage of the isolation mechanism obviously is, that a plugin is loaded in isolation and dependency conflicts therefore are avoided. 
Therefore, we would also like to be able to use the plugin isolation mechanism for the Azure Keyvault secret provider.

The root cause in the Azure SDK has been fixed with [pull request #20760](https://github.com/Azure/azure-sdk-for-java/pull/20760). Since _azure-core_ 1.16.0 the HTTP client is loaded with the classloader that loaded the classes of the _azure-core_ library, which is always the plugin classloader.

In order to take advantage of this new implementation I bumped the version of _azure-security-keyvault-secrets_ to 4.2.0 and _azure-identity_ to 1.3.1. Both depend on _azure-core_ 1.17.0 library, which will allow to use the plugin isolation mechanism provided by Kafka Connect.

It would be create if you could integrate this improvement into the _secret-provider_ library. This would simplify the usage as Kafka Connect plugin together with other plugins. Thanks.