### PR TITLE
AWS Secrets Manager tweaks:

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,16 +12,17 @@ trait Dependencies {
     val kafkaVersion         = "3.4.0"
     val vaultVersion         = "5.1.0"
     val azureKeyVaultVersion = "4.5.2"
-    val azureIdentityVersion = "1.8.0"
-    val awsSecretsVersion    = "1.12.420"
+    val azureIdentityVersion = "1.8.1"
+
+    val awsSdkV2Version = "2.20.26"
 
     //test
     val scalaTestVersion = "3.2.15"
     val mockitoVersion   = "3.2.15.0"
-    val byteBuddyVersion = "1.14.1"
+    val byteBuddyVersion = "1.14.2"
     val slf4jVersion     = "2.0.5"
     val commonsIOVersion = "1.3.2"
-    val jettyVersion     = "11.0.13"
+    val jettyVersion     = "11.0.14"
     val flexmarkVersion  = "0.64.0"
 
     val scalaCollectionCompatVersion = "2.8.1"
@@ -44,8 +45,9 @@ trait Dependencies {
     val `azure-key-vault` =
       "com.azure" % "azure-security-keyvault-secrets" % azureKeyVaultVersion
     val `azure-identity` = "com.azure" % "azure-identity" % azureIdentityVersion
-    val `aws-secrets-manager` =
-      "com.amazonaws" % "aws-java-sdk-secretsmanager" % awsSecretsVersion
+
+    lazy val awsSecretsManagerSdkV2 = "software.amazon.awssdk" % "secretsmanager" % awsSdkV2Version
+    lazy val awsIamSdkV2            = "software.amazon.awssdk" % "iam"            % awsSdkV2Version
 
     val `mockito`      = "org.scalatestplus"   %% "mockito-4-6"  % mockitoVersion
     val `scalatest`    = "org.scalatest"       %% "scalatest"    % scalaTestVersion
@@ -67,9 +69,11 @@ trait Dependencies {
       "org.testcontainers" % "kafka" % testContainersVersion
     val `testContainersVault` =
       "org.testcontainers" % "vault" % testContainersVersion
+
     val `json4sNative`  = "org.json4s"    %% "json4s-native"  % json4sVersion
     val `json4sJackson` = "org.json4s"    %% "json4s-jackson" % json4sVersion
     val `cats`          = "org.typelevel" %% "cats-effect"    % catsEffectVersion
+
   }
 
   import Dependencies._
@@ -79,7 +83,8 @@ trait Dependencies {
     `vault-java-driver`,
     `azure-key-vault`,
     `azure-identity` exclude ("javax.activation", "activation"),
-    `aws-secrets-manager`,
+    `awsSecretsManagerSdkV2`,
+    awsIamSdkV2           % IntegrationTest,
     `jakartaServlet`      % Test,
     `mockito`             % Test,
     `byteBuddy`           % Test,
@@ -100,6 +105,8 @@ trait Dependencies {
     `scala-logging`,
     `kafka-connect-api` % Provided,
     `vault-java-driver`,
+    `awsSecretsManagerSdkV2`,
+    `json4sNative`,
     `scalatest` % Test,
   )
 

--- a/secret-provider/src/it/scala/io/lenses/connect/secrets/integration/VaultSecretProviderIT.scala
+++ b/secret-provider/src/it/scala/io/lenses/connect/secrets/integration/VaultSecretProviderIT.scala
@@ -124,7 +124,7 @@ class VaultSecretProviderIT
       Map(
         "name" -> StringCnfVal(connectorName),
         "connector.class" -> StringCnfVal(
-          "io.lenses.connect.secrets.test.TestSinkConnector",
+          "io.lenses.connect.secrets.test.vault.TestSinkConnector",
         ),
         "topics" -> StringCnfVal(topicName),
         "key.converter" -> StringCnfVal(

--- a/secret-provider/src/it/scala/io/lenses/connect/secrets/testcontainers/VaultContainer.scala
+++ b/secret-provider/src/it/scala/io/lenses/connect/secrets/testcontainers/VaultContainer.scala
@@ -33,13 +33,16 @@ class VaultContainer(maybeLeaseInfo: Option[LeaseInfo] = Option.empty)
   override val container: JavaVaultContainer[_] = new JavaVaultContainer(
     VaultDockerImageName,
   )
-  container.withNetworkAliases(defaultNetworkAlias)
-  container.withVaultToken(token)
+    .withNetworkAliases(defaultNetworkAlias)
+
   container.withEnv(
     "VAULT_LOCAL_CONFIG", //"listener": [{"tcp": { "address": "0.0.0.0:8200", "tls_disable": true}}],
     s"""
        |{${maybeLeaseInfo.fold("")(_.toDurString())} "ui": true}""".stripMargin,
   )
+
+  container.withVaultToken(token)
+
   def vaultClientResource: Resource[IO, Vault] =
     Resource.make(
       IO(
@@ -98,10 +101,10 @@ class VaultContainer(maybeLeaseInfo: Option[LeaseInfo] = Option.empty)
 object VaultContainer {
   val VaultDockerImageName: DockerImageName =
     DockerImageName.parse("vault").withTag("1.12.3")
-  def vaultRootPath     = "rotate-test" // was: secret/
-  def vaultSecretPath   = s"$vaultRootPath/myVaultSecretPath"
-  def vaultSecretKey    = "myVaultSecretKey"
-  def vaultSecretPrefix = "myVaultSecretValue"
+  val vaultRootPath     = "rotate-test" // was: secret/
+  val vaultSecretPath   = s"$vaultRootPath/myVaultSecretPath"
+  val vaultSecretKey    = "myVaultSecretKey"
+  val vaultSecretPrefix = "myVaultSecretValue"
 
   private val defaultNetworkAlias = "vault"
   private val vaultPort: Int = 8200

--- a/secret-provider/src/it/scala/io/lenses/connect/secrets/testcontainers/testcontainers.scala
+++ b/secret-provider/src/it/scala/io/lenses/connect/secrets/testcontainers/testcontainers.scala
@@ -1,7 +1,8 @@
 package io.lenses.connect.secrets
 
+import cats.effect.IO
 import org.testcontainers.containers.KafkaContainer
-
+import software.amazon.awssdk.core.internal.waiters.{ ResponseOrException => AWSResponseOrException }
 package object testcontainers {
 
   implicit class KafkaContainerOps(kafkaContainer: KafkaContainer) {
@@ -10,4 +11,17 @@ package object testcontainers {
     def bootstrapServers: String =
       s"PLAINTEXT://${kafkaContainer.getNetworkAliases.get(0)}:$kafkaPort"
   }
+
+  implicit class ResponseOrException[R](responseOrException: AWSResponseOrException[R]) {
+
+    def toIO(): IO[R] = IO.fromEither(toEither())
+
+    def toEither(): Either[Throwable, R] =
+      Either.cond(
+        responseOrException.response().isPresent,
+        responseOrException.response().get(),
+        responseOrException.exception().get(),
+      )
+  }
+
 }

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/cache/ValueWithTtl.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/cache/ValueWithTtl.scala
@@ -1,15 +1,13 @@
 package io.lenses.connect.secrets.cache
 
 import java.time.Clock
+import java.time.Duration
 import java.time.OffsetDateTime
-import java.time.temporal.ChronoUnit
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.MILLISECONDS
 
 case class Ttl(originalTtl: Duration, expiry: OffsetDateTime) {
 
   def ttlRemaining(implicit clock: Clock): Duration =
-    Duration(expiry.toInstant.toEpochMilli - clock.millis(), MILLISECONDS)
+    Duration.between(clock.instant(), expiry.toInstant)
 
   def isAlive(implicit clock: Clock) = expiry.toInstant.isAfter(clock.instant())
 
@@ -21,7 +19,7 @@ object Ttl {
 
   def ttlToExpiry(ttl: Duration)(implicit clock: Clock): OffsetDateTime = {
     val offset         = clock.getZone.getRules.getOffset(clock.instant())
-    val offsetDateTime = clock.instant().plus(ttl.toMillis, ChronoUnit.MILLIS).atOffset(offset)
+    val offsetDateTime = clock.instant().plus(ttl).atOffset(offset)
     offsetDateTime
   }
 

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderConfig.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderConfig.scala
@@ -6,21 +6,21 @@
 
 package io.lenses.connect.secrets.config
 
-import io.lenses.connect.secrets.connect.AuthMode
 import io.lenses.connect.secrets.connect._
-import org.apache.kafka.common.config.ConfigDef.Importance
-import org.apache.kafka.common.config.ConfigDef.Type
 import org.apache.kafka.common.config.AbstractConfig
 import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.common.config.ConfigDef.Importance
+import org.apache.kafka.common.config.ConfigDef.Type
 
 import java.util
 
 object AWSProviderConfig {
 
-  val AWS_REGION:     String = "aws.region"
-  val AWS_ACCESS_KEY: String = "aws.access.key"
-  val AWS_SECRET_KEY: String = "aws.secret.key"
-  val AUTH_METHOD:    String = "aws.auth.method"
+  val AWS_REGION:        String = "aws.region"
+  val AWS_ACCESS_KEY:    String = "aws.access.key"
+  val AWS_SECRET_KEY:    String = "aws.secret.key"
+  val AUTH_METHOD:       String = "aws.auth.method"
+  val ENDPOINT_OVERRIDE: String = "aws.endpoint.override"
 
   val config: ConfigDef = new ConfigDef()
     .define(
@@ -55,11 +55,32 @@ object AWSProviderConfig {
         |""".stripMargin,
     )
     .define(
+      WRITE_FILES,
+      Type.BOOLEAN,
+      false,
+      Importance.MEDIUM,
+      WRITE_FILES_DESC,
+    )
+    .define(
       FILE_DIR,
       Type.STRING,
       "",
       Importance.MEDIUM,
       FILE_DIR_DESC,
+    )
+    .define(
+      SECRET_DEFAULT_TTL,
+      Type.LONG,
+      SECRET_DEFAULT_TTL_DEFAULT,
+      Importance.MEDIUM,
+      "Default TTL to apply in case a secret has no TTL",
+    )
+    .define(
+      ENDPOINT_OVERRIDE,
+      Type.STRING,
+      "",
+      Importance.LOW,
+      "URL of endpoint override (eg for custom Secret Provider implementations)",
     )
 }
 

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/VaultProviderConfig.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/VaultProviderConfig.scala
@@ -8,6 +8,8 @@ package io.lenses.connect.secrets.config
 
 import io.lenses.connect.secrets.connect.FILE_DIR
 import io.lenses.connect.secrets.connect.FILE_DIR_DESC
+import io.lenses.connect.secrets.connect.SECRET_DEFAULT_TTL
+import io.lenses.connect.secrets.connect.SECRET_DEFAULT_TTL_DEFAULT
 import io.lenses.connect.secrets.connect.WRITE_FILES
 import io.lenses.connect.secrets.connect.WRITE_FILES_DESC
 import org.apache.kafka.common.config.ConfigDef.Importance
@@ -77,9 +79,6 @@ object VaultProviderConfig {
 
   val TOKEN_RENEWAL:         String = "token.renewal.ms"
   val TOKEN_RENEWAL_DEFAULT: Int    = 600000
-
-  val SECRET_DEFAULT_TTL         = "secret.default.ttl"
-  val SECRET_DEFAULT_TTL_DEFAULT = 0L
 
   val config: ConfigDef = new ConfigDef()
     .define(

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/package.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/package.scala
@@ -40,6 +40,9 @@ package object connect extends StrictLogging {
       | keystores etc.
       |""".stripMargin
 
+  val SECRET_DEFAULT_TTL         = "secret.default.ttl"
+  val SECRET_DEFAULT_TTL_DEFAULT = 0L
+
   object AuthMode extends Enumeration {
     type AuthMode = Value
     val DEFAULT, CREDENTIALS = Value

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/SecretHelper.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/SecretHelper.scala
@@ -1,0 +1,10 @@
+package io.lenses.connect.secrets.providers
+
+import io.lenses.connect.secrets.cache.ValueWithTtl
+
+trait SecretHelper {
+
+  def lookup(path: String): Either[Throwable, ValueWithTtl[Map[String, String]]]
+
+  def close(): Unit = ()
+}

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/SecretProvider.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/SecretProvider.scala
@@ -1,0 +1,63 @@
+package io.lenses.connect.secrets.providers
+
+import com.typesafe.scalalogging.LazyLogging
+import io.lenses.connect.secrets.cache.TtlCache
+import io.lenses.connect.secrets.cache.ValueWithTtl
+import io.lenses.connect.secrets.utils.ConfigDataBuilder
+import org.apache.kafka.common.config.ConfigData
+import org.apache.kafka.connect.errors.ConnectException
+
+import java.time.Clock
+import java.util
+import scala.jdk.CollectionConverters.SetHasAsScala
+
+class SecretProvider(
+  providerName:   String,
+  getSecretValue: String => Either[Throwable, ValueWithTtl[Map[String, String]]],
+  closeFn:        () => Unit = () => (),
+)(
+  implicit
+  clock: Clock,
+) extends LazyLogging {
+
+  private val cache = new TtlCache[Map[String, String]](k => getSecretValue(k))
+
+  // lookup secrets at a path
+  def get(path: String): ConfigData = {
+    logger.debug(" -> {}.get(path: {})", providerName, path)
+    val sec = cache
+      .cachingWithTtl(
+        path,
+      )
+      .fold(
+        ex => throw new ConnectException(ex),
+        ConfigDataBuilder(_),
+      )
+    logger.debug(" <- {}.get(path: {}, ttl: {})", providerName, path, sec.ttl())
+    sec
+  }
+
+  // get secret keys at a path
+  def get(path: String, keys: util.Set[String]): ConfigData = {
+    logger.debug(" -> {}.get(path: {}, keys: {})", providerName, path, keys.asScala)
+    val sec = cache.cachingWithTtl(
+      path,
+      fnCondition        = s => keys.asScala.subsetOf(s.keySet),
+      fnFilterReturnKeys = filter(_, keys.asScala.toSet),
+    ).fold(
+      ex => throw new ConnectException(ex),
+      ConfigDataBuilder(_),
+    )
+    logger.debug(" <- {}.get(path: {}, keys: {}, ttl: {})", providerName, path, keys.asScala, sec.ttl())
+    sec
+  }
+
+  def close(): Unit = closeFn()
+
+  private def filter(
+    configData: ValueWithTtl[Map[String, String]],
+    keys:       Set[String],
+  ): ValueWithTtl[Map[String, String]] =
+    configData.copy(value = configData.value.filter { case (k, _) => keys.contains(k) })
+
+}

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/VaultHelper.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/VaultHelper.scala
@@ -9,14 +9,79 @@ package io.lenses.connect.secrets.providers
 import com.bettercloud.vault.SslConfig
 import com.bettercloud.vault.Vault
 import com.bettercloud.vault.VaultConfig
+import com.bettercloud.vault.response.LogicalResponse
+import com.typesafe.scalalogging.LazyLogging
 import com.typesafe.scalalogging.StrictLogging
+import io.lenses.connect.secrets.cache.ValueWithTtl
 import io.lenses.connect.secrets.config.VaultAuthMethod
 import io.lenses.connect.secrets.config.VaultSettings
+import io.lenses.connect.secrets.connect.decodeKey
+import io.lenses.connect.secrets.io.FileWriterOnce
+import io.lenses.connect.secrets.utils.EncodingAndId
+import io.lenses.connect.secrets.utils.ExceptionUtils.failWithEx
 import org.apache.kafka.connect.errors.ConnectException
 
 import java.io.File
+import java.time.temporal.ChronoUnit
+import java.time.Clock
+import java.time.Duration
+import scala.jdk.CollectionConverters.MapHasAsScala
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
-trait VaultHelper extends StrictLogging {
+class VaultHelper(
+  vaultClient:        Vault,
+  defaultTtl:         Option[Duration],
+  fileWriterCreateFn: String => Option[FileWriterOnce],
+)(
+  implicit
+  clock: Clock,
+) extends SecretHelper
+    with LazyLogging {
+  override def lookup(path: String): Either[Throwable, ValueWithTtl[Map[String, String]]] = {
+    logger.debug(s"Looking up value from Vault at [$path]")
+    Try(vaultClient.logical().read(path)) match {
+      case Failure(ex) =>
+        failWithEx(s"Failed to fetch secrets from path [$path]", ex)
+      case Success(response) if response.getRestResponse.getStatus != 200 =>
+        failWithEx(
+          s"No secrets found at path [$path]. Vault response: ${new String(response.getRestResponse.getBody)}",
+        )
+      case Success(response) if response.getData.isEmpty =>
+        failWithEx(s"No secrets found at path [$path]")
+      case Success(response) =>
+        val ttl =
+          Option(response.getLeaseDuration).filterNot(_ == 0L).map(Duration.of(_, ChronoUnit.SECONDS))
+        Right(
+          ValueWithTtl(ttl, defaultTtl, parseSuccessfulResponse(path, response)),
+        )
+    }
+  }
+
+  private def parseSuccessfulResponse(
+    path:     String,
+    response: LogicalResponse,
+  ) = {
+    val secretValues    = response.getData.asScala
+    val fileWriterMaybe = fileWriterCreateFn(path)
+    secretValues.map {
+      case (k, v) =>
+        (k,
+         decodeKey(
+           encoding = EncodingAndId.from(k).encoding,
+           key      = k,
+           value    = v,
+           writeFileFn = { content =>
+             fileWriterMaybe.fold("nofile")(_.write(k.toLowerCase, content, k).toString)
+           },
+         ),
+        )
+    }.toMap
+  }
+}
+
+object VaultHelper extends StrictLogging {
 
   // initialize the vault client
   def createClient(settings: VaultSettings): Vault = {

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/VaultSecretProvider.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/VaultSecretProvider.scala
@@ -7,44 +7,43 @@
 package io.lenses.connect.secrets.providers
 
 import com.bettercloud.vault.Vault
-import com.bettercloud.vault.response.LogicalResponse
 import io.lenses.connect.secrets.async.AsyncFunctionLoop
-import io.lenses.connect.secrets.cache.TtlCache
-import io.lenses.connect.secrets.cache.ValueWithTtl
 import io.lenses.connect.secrets.config.VaultProviderConfig
 import io.lenses.connect.secrets.config.VaultSettings
-import io.lenses.connect.secrets.connect._
-import io.lenses.connect.secrets.utils.ConfigDataBuilder
-import io.lenses.connect.secrets.utils.EncodingAndId
-import io.lenses.connect.secrets.utils.ExceptionUtils.failWithEx
+import io.lenses.connect.secrets.providers.VaultHelper.createClient
 import org.apache.kafka.common.config.ConfigData
 import org.apache.kafka.common.config.provider.ConfigProvider
+import org.apache.kafka.connect.errors.ConnectException
 
 import java.time.Clock
 import java.util
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.Duration
-import scala.jdk.CollectionConverters.MapHasAsScala
-import scala.jdk.CollectionConverters.SetHasAsScala
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 
-class VaultSecretProvider() extends ConfigProvider with VaultHelper {
-
-  private var settings:     VaultSettings             = _
-  private var vaultClient:  Option[Vault]             = None
-  private var tokenRenewal: Option[AsyncFunctionLoop] = None
-
+class VaultSecretProvider() extends ConfigProvider {
   private implicit val clock: Clock = Clock.systemDefaultZone()
-  private val cache = new TtlCache[Map[String, String]](k => getSecretValue(k))
 
-  def getClient: Option[Vault] = vaultClient
+  private var maybeVaultClient: Option[Vault]             = None
+  private var tokenRenewal:     Option[AsyncFunctionLoop] = None
+  private var secretProvider:   Option[SecretProvider]    = None
+
+  def getClient: Option[Vault] = maybeVaultClient
 
   // configure the vault client
   override def configure(configs: util.Map[String, _]): Unit = {
-    settings    = VaultSettings(VaultProviderConfig(configs))
-    vaultClient = Some(createClient(settings))
+    val settings    = VaultSettings(VaultProviderConfig(configs))
+    val vaultClient = createClient(settings)
+
+    val helper = new VaultHelper(
+      vaultClient,
+      settings.defaultTtl,
+      fileWriterCreateFn = path => settings.fileWriterOpts.map(_.createFileWriter(path)),
+    )
+
+    secretProvider   = Some(new SecretProvider(getClass.getSimpleName, helper.lookup))
+    maybeVaultClient = Some(vaultClient)
+    createRenewalLoop(settings)
+  }
+
+  private def createRenewalLoop(settings: VaultSettings): Unit = {
     val renewalLoop = {
       new AsyncFunctionLoop(settings.tokenRenewal, "Vault Token Renewal")(
         renewToken(),
@@ -58,87 +57,14 @@ class VaultSecretProvider() extends ConfigProvider with VaultHelper {
   def tokenRenewalFailure: Long = tokenRenewal.map(_.failureRate).getOrElse(-1)
 
   private def renewToken(): Unit =
-    vaultClient.foreach(client => client.auth().renewSelf())
-
-  // lookup secrets at a path
-  override def get(path: String): ConfigData = {
-    logger.debug(" -> VaultSecretProvider.get(path: {})", path)
-    val sec = cache
-      .cachingWithTtl(
-        path,
-      )
-      .fold(
-        ex => throw ex,
-        ConfigDataBuilder(_),
-      )
-    logger.debug(" <- VaultSecretProvider.get(path: {}, ttl: {})", path, sec.ttl())
-    sec
-  }
-
-  // get secret keys at a path
-  override def get(path: String, keys: util.Set[String]): ConfigData = {
-    logger.debug(" -> VaultSecretProvider.get(path: {}, keys: {})", path, keys.asScala)
-    val sec = cache.cachingWithTtl(
-      path,
-      fnCondition        = s => keys.asScala.subsetOf(s.keySet),
-      fnFilterReturnKeys = filter(_, keys.asScala.toSet),
-    ).fold(
-      ex => throw ex,
-      ConfigDataBuilder(_),
-    )
-    logger.debug(" <- VaultSecretProvider.get(path: {}, keys: {}, ttl: {})", path, keys.asScala, sec.ttl())
-    sec
-  }
-
-  private def filter(
-    configData: ValueWithTtl[Map[String, String]],
-    keys:       Set[String],
-  ): ValueWithTtl[Map[String, String]] =
-    configData.copy(value = configData.value.filter { case (k, _) => keys.contains(k) })
+    maybeVaultClient.foreach(client => client.auth().renewSelf())
 
   override def close(): Unit =
     tokenRenewal.foreach(_.close())
 
-  // get the secrets and ttl under a path
-  val getSecretValue: String => Either[Throwable, ValueWithTtl[Map[String, String]]] = path => {
-    logger.debug(s"Looking up value from Vault at [$path]")
-    Try(vaultClient.get.logical().read(path)) match {
-      case Failure(ex) =>
-        failWithEx(s"Failed to fetch secrets from path [$path]", ex)
-      case Success(response) if response.getRestResponse.getStatus != 200 =>
-        failWithEx(
-          s"No secrets found at path [$path]. Vault response: ${new String(response.getRestResponse.getBody)}",
-        )
-      case Success(response) if response.getData.isEmpty =>
-        failWithEx(s"No secrets found at path [$path]")
-      case Success(response) =>
-        val ttl =
-          Option(response.getLeaseDuration).filterNot(_ == 0L).map(Duration(_, TimeUnit.SECONDS))
-        Right(
-          ValueWithTtl(ttl, settings.defaultTtl, parseSuccessfulResponse(path, response)),
-        )
-    }
-  }
+  override def get(path: String): ConfigData =
+    secretProvider.fold(throw new ConnectException("Vault client is not set."))(_.get(path))
 
-  private def parseSuccessfulResponse(
-    path:     String,
-    response: LogicalResponse,
-  ) = {
-    val fileWriterMaybe = settings.fileWriterOpts.map(_.createFileWriter(path))
-    response.getData.asScala.map {
-      case (k, v) =>
-        val encodingAndId = EncodingAndId.from(k)
-        val decoded =
-          decodeKey(
-            encoding = encodingAndId.encoding,
-            key      = k,
-            value    = v,
-            writeFileFn = { content =>
-              fileWriterMaybe.fold("nofile")(_.write(k.toLowerCase, content, k).toString)
-            },
-          )
-        (k, decoded)
-    }.toMap
-  }
-
+  override def get(path: String, keys: util.Set[String]): ConfigData =
+    secretProvider.fold(throw new ConnectException("Vault client is not set."))(_.get(path, keys))
 }

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/cache/TtlTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/cache/TtlTest.scala
@@ -4,12 +4,11 @@ import org.scalatest.OptionValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import java.time.temporal.ChronoUnit
+import java.time.temporal.ChronoUnit._
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.MINUTES
 
 class TtlTest extends AnyFunSuite with Matchers with OptionValues {
   implicit val clock = Clock.fixed(Instant.EPOCH, ZoneId.systemDefault())
@@ -19,24 +18,24 @@ class TtlTest extends AnyFunSuite with Matchers with OptionValues {
   }
 
   test("ttl returned with record should be used") {
-    val ttl = Ttl(Some(Duration(5, MINUTES)), Option.empty)
-    ttl.value.originalTtl should be(Duration(5, MINUTES))
-    ttl.value.expiry should be(Instant.EPOCH.plus(5, ChronoUnit.MINUTES).atOffset(toOffset))
+    val ttl = Ttl(Some(Duration.of(5, MINUTES)), Option.empty)
+    ttl.value.originalTtl should be(Duration.of(5, MINUTES))
+    ttl.value.expiry should be(Instant.EPOCH.plus(5, MINUTES).atOffset(toOffset))
   }
 
   private def toOffset =
     clock.getZone.getRules.getOffset(clock.instant())
 
   test("default ttl should apply if not available") {
-    val ttl = Ttl(Option.empty, Some(Duration(5, MINUTES)))
-    ttl.value.originalTtl should be(Duration(5, MINUTES))
-    ttl.value.expiry should be(Instant.EPOCH.plus(5, ChronoUnit.MINUTES).atOffset(toOffset))
+    val ttl = Ttl(Option.empty, Some(Duration.of(5, MINUTES)))
+    ttl.value.originalTtl should be(Duration.of(5, MINUTES))
+    ttl.value.expiry should be(Instant.EPOCH.plus(5, MINUTES).atOffset(toOffset))
   }
 
   test("record ttl should be preferred over default") {
-    val ttl = Ttl(Some(Duration(10, MINUTES)), Some(Duration(5, MINUTES)))
-    ttl.value.originalTtl should be(Duration(10, MINUTES))
-    ttl.value.expiry should be(Instant.EPOCH.plus(10, ChronoUnit.MINUTES).atOffset(toOffset))
+    val ttl = Ttl(Some(Duration.of(10, MINUTES)), Some(Duration.of(5, MINUTES)))
+    ttl.value.originalTtl should be(Duration.of(10, MINUTES))
+    ttl.value.expiry should be(Instant.EPOCH.plus(10, MINUTES).atOffset(toOffset))
   }
 
 }

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/utils/ConfigDataBuilderTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/utils/ConfigDataBuilderTest.scala
@@ -5,16 +5,15 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import java.time.Clock
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration.MINUTES
-
+import java.time.Duration
+import java.time.temporal.ChronoUnit._
 class ConfigDataBuilderTest extends AnyFunSuite with Matchers {
 
   implicit val clock = Clock.systemDefaultZone()
 
   test("Converts to the expected java structure") {
     val map = ValueWithTtl(
-      Option(Duration(1, MINUTES)),
+      Option(Duration.of(1, MINUTES)),
       Option.empty[Duration],
       Map[String, String](
         "secret" -> "12345",

--- a/test-sink/src/main/scala/io/lenses/connect/secrets/test/vault/TestSinkConnector.scala
+++ b/test-sink/src/main/scala/io/lenses/connect/secrets/test/vault/TestSinkConnector.scala
@@ -1,4 +1,4 @@
-package io.lenses.connect.secrets.test
+package io.lenses.connect.secrets.test.vault
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.common.config.ConfigDef

--- a/test-sink/src/main/scala/io/lenses/connect/secrets/test/vault/TestSinkTask.scala
+++ b/test-sink/src/main/scala/io/lenses/connect/secrets/test/vault/TestSinkTask.scala
@@ -1,7 +1,7 @@
-package io.lenses.connect.secrets.test
+package io.lenses.connect.secrets.test.vault
 
 import com.typesafe.scalalogging.LazyLogging
-import io.lenses.connect.secrets.test.VaultStateValidator.validateSecret
+import VaultStateValidator.validateSecret
 import org.apache.kafka.connect.sink.SinkRecord
 import org.apache.kafka.connect.sink.SinkTask
 import org.apache.kafka.connect.sink.SinkTaskContext

--- a/test-sink/src/main/scala/io/lenses/connect/secrets/test/vault/VaultState.scala
+++ b/test-sink/src/main/scala/io/lenses/connect/secrets/test/vault/VaultState.scala
@@ -1,4 +1,4 @@
-package io.lenses.connect.secrets.test
+package io.lenses.connect.secrets.test.vault
 
 import com.bettercloud.vault.Vault
 import com.bettercloud.vault.VaultConfig

--- a/test-sink/src/main/scala/io/lenses/connect/secrets/test/vault/VaultStateValidator.scala
+++ b/test-sink/src/main/scala/io/lenses/connect/secrets/test/vault/VaultStateValidator.scala
@@ -1,4 +1,4 @@
-package io.lenses.connect.secrets.test
+package io.lenses.connect.secrets.test.vault
 
 import com.typesafe.scalalogging.LazyLogging
 


### PR DESCRIPTION
AWS Secrets Manager secrets:
* Adding default ttl (`secret.default.ttl`)
* Enable bypassing file writing (`file.write`)
* Add endpoint override (`aws.endpoint.override`)
* Ensuring secrets are cached within their TTL (same as Vault)
* Upgrade dependencies to use AWS V2 Client
* Consistently use `java.time.Duration` instead of `scala.concurrent.Duration` to avoid conversions