### PR TITLE
AWS — added feature to read secrets from other accounts

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -15,7 +15,7 @@ object Settings extends Dependencies {
   val scala213 = "2.13.10"
   val scala3   = "3.2.2"
 
-  val nextVersion = "2.1.7"
+  val nextVersion = "2.2.1"
   val artifactVersion = {
     sys.env.get("LENSES_TAG_NAME") match {
       case Some(tag) => tag

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderConfig.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderConfig.scala
@@ -21,6 +21,7 @@ object AWSProviderConfig {
   val AWS_SECRET_KEY:    String = "aws.secret.key"
   val AUTH_METHOD:       String = "aws.auth.method"
   val ENDPOINT_OVERRIDE: String = "aws.endpoint.override"
+  val AWS_CROSS_ACCOUNT_REGION:        String = "aws.cross.account.region"
 
   val config: ConfigDef = new ConfigDef()
     .define(
@@ -53,6 +54,13 @@ object AWSProviderConfig {
         | or 'default' for the standard AWS provider chain.
         | Default is 'credentials'
         |""".stripMargin,
+    )
+    .define(
+      AWS_CROSS_ACCOUNT_REGION,
+      Type.STRING,
+      "",
+      Importance.MEDIUM,
+      "AWS region the Secrets manager is in when reading from alternate account",
     )
     .define(
       WRITE_FILES,

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderSettings.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderSettings.scala
@@ -23,6 +23,7 @@ case class AWSProviderSettings(
   fileWriterOpts:   Option[FileWriterOptions],
   defaultTtl:       Option[Duration],
   endpointOverride: Option[String],
+  altRegion:        String
 )
 
 import io.lenses.connect.secrets.config.AbstractConfigExtensions._
@@ -38,6 +39,8 @@ object AWSProviderSettings {
     val endpointOverride = Try(configs.getString("aws.endpoint.override")).toOption.filterNot(_.trim.isEmpty)
     val authMode =
       getAuthenticationMethod(configs.getString(AWSProviderConfig.AUTH_METHOD))
+
+    val altRegion = configs.getString("aws.cross.account.region")
 
     if (authMode == AuthMode.CREDENTIALS) {
       if (accessKey.isEmpty)
@@ -59,6 +62,7 @@ object AWSProviderSettings {
       defaultTtl =
         Option(configs.getLong(SECRET_DEFAULT_TTL).toLong).filterNot(_ == 0L).map(Duration.of(_, ChronoUnit.MILLIS)),
       endpointOverride,
+      altRegion      = altRegion
     )
   }
 }

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSHelper.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSHelper.scala
@@ -50,11 +50,8 @@ class AWSHelper(
   // get the key value and ttl in the specified secret
   override def lookup(secretId: String): Either[Throwable, ValueWithTtl[Map[String, String]]] = {
     val hasAccount = secretId.indexOf("$")
-    val secretName = secretId
-    if (hasAccount > -1) {
-      val secret_array = secretId.split("\\$")
-      val secretName = s"arn:aws:secretsmanager:us-east-1:${secret_array(0)}:secret:${secret_array(1)}"
-    }
+    val secret_array = secretId.split("\\$")
+    val secretName = if (hasAccount > -1) s"arn:aws:secretsmanager:us-east-1:${secret_array(0)}:secret:${secret_array(1)}" else secretId
     for {
       secretTtl         <- getTTL(secretName)
       secretValue       <- getSecretValue(secretName)

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSHelper.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSHelper.scala
@@ -38,7 +38,8 @@ import scala.util.Try
 class AWSHelper(
   client:             SecretsManagerClient,
   defaultTtl:         Option[Duration],
-  fileWriterCreateFn: () => Option[FileWriter],
+  altRegion:          String,
+  fileWriterCreateFn: () => Option[FileWriter]
 )(
   implicit
   clock: Clock,
@@ -51,7 +52,8 @@ class AWSHelper(
   override def lookup(secretId: String): Either[Throwable, ValueWithTtl[Map[String, String]]] = {
     val hasAccount = secretId.indexOf("$")
     val secret_array = secretId.split("\\$")
-    val secretName = if (hasAccount > -1) s"arn:aws:secretsmanager:us-east-1:${secret_array(0)}:secret:${secret_array(1)}" else secretId
+    val region = if (altRegion.length > 0) altRegion else ""
+    val secretName = if (hasAccount > -1) s"arn:aws:secretsmanager:${region}:${secret_array(0)}:secret:${secret_array(1)}" else secretId
     for {
       secretTtl         <- getTTL(secretName)
       secretValue       <- getSecretValue(secretName)

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSSecretProvider.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSSecretProvider.scala
@@ -30,6 +30,7 @@ class AWSSecretProvider(testClient: Option[SecretsManagerClient]) extends Config
     val awsClient = testClient.getOrElse(createClient(settings))
     val helper = new AWSHelper(awsClient,
                                settings.defaultTtl,
+                               settings.altRegion,
                                fileWriterCreateFn = () => settings.fileWriterOpts.map(_.createFileWriter()),
     )
     secretProvider = Some(

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSSecretProvider.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSSecretProvider.scala
@@ -30,6 +30,7 @@ class AWSSecretProvider(testClient: Option[SecretsManagerClient]) extends Config
     val awsClient = testClient.getOrElse(createClient(settings))
     val helper = new AWSHelper(awsClient,
                                settings.defaultTtl,
+                               settings.region,
                                settings.altRegion,
                                fileWriterCreateFn = () => settings.fileWriterOpts.map(_.createFileWriter()),
     )


### PR DESCRIPTION
By prefixing the secret name with the account ID and a dollar sign ($), the provider will now construct the full secret ARN before calling getSecretValue(), therefore enabling the AWS API to find secrets located in any account that the configured user is authorized to access.

e.g. `${aws:databases/credentials:password}` will call getSecretValue('databases/credentials'), defaulting to the configured account, whereas `${aws:123456789012$databases/credentials:password}` will provide the full ARN of `arn:aws:secretsmanager:us-east-1:123456789012:secret:databases/credentials`

If the cross-account secret is located in a different region, you can specify that via the `aws.cross.account.region` configuration.