### PR TITLE
Add support for AWS SecretsManager non key value pair secrets

### DIFF
--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderConfig.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderConfig.scala
@@ -22,66 +22,69 @@ object AWSProviderConfig {
   val AUTH_METHOD:       String = "aws.auth.method"
   val ENDPOINT_OVERRIDE: String = "aws.endpoint.override"
 
-  val config: ConfigDef = new ConfigDef()
-    .define(
-      AWS_REGION,
-      Type.STRING,
-      Importance.HIGH,
-      "AWS region the Secrets manager is in",
-    )
-    .define(
-      AWS_ACCESS_KEY,
-      Type.STRING,
-      null,
-      Importance.HIGH,
-      "AWS access key",
-    )
-    .define(
-      AWS_SECRET_KEY,
-      Type.PASSWORD,
-      null,
-      Importance.HIGH,
-      "AWS password key",
-    )
-    .define(
-      AUTH_METHOD,
-      Type.STRING,
-      AuthMode.CREDENTIALS.toString,
-      Importance.HIGH,
-      """
-        | AWS authenticate method, 'credentials' to use the provided credentials 
-        | or 'default' for the standard AWS provider chain.
-        | Default is 'credentials'
-        |""".stripMargin,
-    )
-    .define(
-      WRITE_FILES,
-      Type.BOOLEAN,
-      false,
-      Importance.MEDIUM,
-      WRITE_FILES_DESC,
-    )
-    .define(
-      FILE_DIR,
-      Type.STRING,
-      "",
-      Importance.MEDIUM,
-      FILE_DIR_DESC,
-    )
-    .define(
-      SECRET_DEFAULT_TTL,
-      Type.LONG,
-      SECRET_DEFAULT_TTL_DEFAULT,
-      Importance.MEDIUM,
-      "Default TTL to apply in case a secret has no TTL",
-    )
-    .define(
-      ENDPOINT_OVERRIDE,
-      Type.STRING,
-      "",
-      Importance.LOW,
-      "URL of endpoint override (eg for custom Secret Provider implementations)",
-    )
+  val config: ConfigDef = {
+    val cDef = new ConfigDef()
+      .define(
+        AWS_REGION,
+        Type.STRING,
+        Importance.HIGH,
+        "AWS region the Secrets manager is in",
+      )
+      .define(
+        AWS_ACCESS_KEY,
+        Type.STRING,
+        null,
+        Importance.HIGH,
+        "AWS access key",
+      )
+      .define(
+        AWS_SECRET_KEY,
+        Type.PASSWORD,
+        null,
+        Importance.HIGH,
+        "AWS password key",
+      )
+      .define(
+        AUTH_METHOD,
+        Type.STRING,
+        AuthMode.CREDENTIALS.toString,
+        Importance.HIGH,
+        """
+          | AWS authenticate method, 'credentials' to use the provided credentials
+          | or 'default' for the standard AWS provider chain.
+          | Default is 'credentials'
+          |""".stripMargin,
+      )
+      .define(
+        WRITE_FILES,
+        Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        WRITE_FILES_DESC,
+      )
+      .define(
+        FILE_DIR,
+        Type.STRING,
+        "",
+        Importance.MEDIUM,
+        FILE_DIR_DESC,
+      )
+      .define(
+        SECRET_DEFAULT_TTL,
+        Type.LONG,
+        SECRET_DEFAULT_TTL_DEFAULT,
+        Importance.MEDIUM,
+        "Default TTL to apply in case a secret has no TTL",
+      )
+      .define(
+        ENDPOINT_OVERRIDE,
+        Type.STRING,
+        "",
+        Importance.LOW,
+        "URL of endpoint override (eg for custom Secret Provider implementations)",
+      )
+    SecretTypeConfig.addSecretTypeToConfigDef(cDef)
+  }
 }
 
 case class AWSProviderConfig(props: util.Map[String, _]) extends AbstractConfig(AWSProviderConfig.config, props)

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/SecretTypeConfig.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/SecretTypeConfig.scala
@@ -1,0 +1,43 @@
+package io.lenses.connect.secrets.config
+
+import io.lenses.connect.secrets.config.SecretType.SecretType
+import org.apache.kafka.common.config.ConfigDef
+import org.apache.kafka.common.config.ConfigDef.Importance
+import org.apache.kafka.common.config.ConfigDef.Type
+import org.apache.kafka.connect.errors.ConnectException
+
+import scala.util.Try
+
+object SecretType extends Enumeration {
+
+  type SecretType = Value
+  val STRING, JSON = Value
+}
+object SecretTypeConfig {
+  val SECRET_TYPE: String = "secret.type"
+
+  def addSecretTypeToConfigDef(configDef: ConfigDef): ConfigDef =
+    configDef.define(
+      SECRET_TYPE,
+      Type.STRING,
+      "",
+      Importance.LOW,
+      "Type of secret to retrieve (string, json)",
+    )
+
+  def lookupAndValidateSecretTypeValue(propLookup: String => String): SecretType = {
+    for {
+      secretTypeString <- Try(propLookup(SecretTypeConfig.SECRET_TYPE)).toOption.filterNot(st =>
+        st == null || st.isEmpty,
+      )
+      secretTypeEnum <- Try {
+        SecretType.withName(secretTypeString.toUpperCase)
+      }.toEither.left.map(_ =>
+        throw new ConnectException(
+          s"$secretTypeString is not a valid secret type. Please check your ${SecretTypeConfig.SECRET_TYPE} property.",
+        ),
+      ).toOption
+    } yield secretTypeEnum
+  }.getOrElse(SecretType.JSON)
+
+}

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSSecretProvider.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AWSSecretProvider.scala
@@ -31,6 +31,7 @@ class AWSSecretProvider(testClient: Option[SecretsManagerClient]) extends Config
     val helper = new AWSHelper(awsClient,
                                settings.defaultTtl,
                                fileWriterCreateFn = () => settings.fileWriterOpts.map(_.createFileWriter()),
+                               settings.secretType,
     )
     secretProvider = Some(
       new SecretProvider(

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/config/SecretTypeConfigTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/config/SecretTypeConfigTest.scala
@@ -1,0 +1,37 @@
+package io.lenses.connect.secrets.config
+
+import org.apache.kafka.connect.errors.ConnectException
+import org.mockito.Mockito.when
+import org.scalatest.OptionValues
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+class SecretTypeConfigTest extends AnyFunSuite with Matchers with OptionValues with MockitoSugar {
+
+  test("lookupAndValidateSecretTypeValue should throw accept valid types") {
+    SecretTypeConfig.lookupAndValidateSecretTypeValue(mockSecretReturn("string")) should be(SecretType.STRING)
+    SecretTypeConfig.lookupAndValidateSecretTypeValue(mockSecretReturn("STRING")) should be(SecretType.STRING)
+    SecretTypeConfig.lookupAndValidateSecretTypeValue(mockSecretReturn("json")) should be(SecretType.JSON)
+    SecretTypeConfig.lookupAndValidateSecretTypeValue(mockSecretReturn("JSON")) should be(SecretType.JSON)
+  }
+
+  test("lookupAndValidateSecretTypeValue should throw error on invalid type") {
+    val secRetFn = mockSecretReturn("nonExistentSecretType")
+    intercept[ConnectException] {
+      SecretTypeConfig.lookupAndValidateSecretTypeValue(secRetFn)
+    }.getMessage should startWith("nonExistentSecretType is not a valid secret type")
+  }
+
+  test("lookupAndValidateSecretTypeValue should return json by default") {
+    SecretTypeConfig.lookupAndValidateSecretTypeValue(mockSecretReturn(null)) should be(SecretType.JSON)
+    SecretTypeConfig.lookupAndValidateSecretTypeValue(mockSecretReturn("")) should be(SecretType.JSON)
+  }
+
+  private def mockSecretReturn(out: String): String => String = {
+    val mockFn = mock[String => String]
+    when(mockFn.apply(SecretTypeConfig.SECRET_TYPE)).thenReturn(out)
+    mockFn
+  }
+
+}

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/VaultSecretProviderTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/VaultSecretProviderTest.scala
@@ -134,7 +134,7 @@ class VaultSecretProviderTest extends AnyWordSpec with Matchers with BeforeAndAf
     val data2 = provider.get("secret/hello")
 
     (data1.ttl > data2.ttl) shouldBe true
-    (data1.ttl() - data2.ttl()) should be > 5000L
+    (data1.ttl() - data2.ttl()) should be >= 5000L
     data2.ttl().longValue() should be < 9995000L
   }
 


### PR DESCRIPTION
This is a rebase/rework of https://github.com/lensesio/secret-provider/pull/24 by @adrianisk against the latest version of the code base.

# Summary

Adds support for pulling secrets that aren't stored as key value pairs, which is useful if you organize secrets as one secret per path. To use you can configure the new property to instruct the secret provider to treat the contents of the secret as a string::
```
config.providers.vault.param.secret.type=STRING
```

and retrieve the string value of the secret using the `value` key
```
${aws:production/some_service/database/password:value}
```
and the secret-provider returns the full string contents of the secret stored at the path.

# Tests

I added a unit test to verify this works, and have also tested in a local Kafka Connect cluster pulling a real secret from AWS SecretsManager.