### PR TITLE
Recompute TTL values on each `get`

### DIFF
--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/package.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/package.scala
@@ -7,7 +7,6 @@
 package io.lenses.connect.secrets
 
 import com.typesafe.scalalogging.StrictLogging
-import org.apache.kafka.common.config.ConfigData
 import org.apache.kafka.connect.errors.ConnectException
 
 import java.io.File
@@ -15,7 +14,6 @@ import java.io.FileOutputStream
 import java.time.OffsetDateTime
 import java.util.Base64
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -150,7 +148,7 @@ package object connect extends StrictLogging {
   //calculate the min expiry for secrets and return the configData and expiry
   def getSecretsAndExpiry(
     secrets: Map[String, (String, Option[OffsetDateTime])],
-  ): (Option[OffsetDateTime], ConfigData) = {
+  ): (Option[OffsetDateTime], Map[String, String]) = {
     val expiryList = mutable.ListBuffer.empty[OffsetDateTime]
 
     val data = secrets
@@ -159,15 +157,12 @@ package object connect extends StrictLogging {
           expiry.foreach(e => expiryList.append(e))
           (key, value)
       })
-      .asJava
 
     if (expiryList.isEmpty) {
-      (None, new ConfigData(data))
+      (None, data)
     } else {
       val minExpiry = expiryList.min
-      val ttl = minExpiry.toInstant.toEpochMilli - OffsetDateTime.now.toInstant
-        .toEpochMilli
-      (Some(minExpiry), new ConfigData(data, ttl))
+      (Some(minExpiry), data)
     }
   }
 

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/AzureSecretProviderTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/AzureSecretProviderTest.scala
@@ -15,7 +15,6 @@ import io.lenses.connect.secrets.config.AzureProviderSettings
 import io.lenses.connect.secrets.connect
 import io.lenses.connect.secrets.connect.AuthMode
 import org.apache.kafka.common.config.provider.ConfigProvider
-import org.apache.kafka.common.config.ConfigData
 import org.apache.kafka.common.config.ConfigTransformer
 import org.apache.kafka.connect.errors.ConnectException
 import org.mockito.Mockito.when
@@ -236,7 +235,7 @@ class AzureSecretProviderTest extends AnyWordSpec with Matchers with MockitoSuga
     // poke in the mocked client
     provider.clientMap += (s"https://$secretPath" -> client)
     val now        = OffsetDateTime.now().plusMinutes(10)
-    val cachedData = new ConfigData(Map(secretKey -> secretPath).asJava)
+    val cachedData = Map(secretKey -> secretPath)
     val cached     = (Some(now), cachedData)
 
     // add to cache
@@ -283,7 +282,7 @@ class AzureSecretProviderTest extends AnyWordSpec with Matchers with MockitoSuga
     provider.clientMap += (vaultUrl -> client)
     //put expiry of cache 1 second behind
     val now        = OffsetDateTime.now().minusSeconds(1)
-    val cachedData = new ConfigData(Map(secretKey -> secretPath).asJava)
+    val cachedData = Map(secretKey -> secretPath)
     val cached     = (Some(now), cachedData)
 
     // add to cache
@@ -332,7 +331,7 @@ class AzureSecretProviderTest extends AnyWordSpec with Matchers with MockitoSuga
     provider.clientMap += (vaultUrl -> client)
     //put expiry of cache 1 second behind
     val now        = OffsetDateTime.now()
-    val cachedData = new ConfigData(Map("old-key" -> secretPath).asJava)
+    val cachedData = Map("old-key" -> secretPath)
     val cached     = (Some(now), cachedData)
 
     // add to cache


### PR DESCRIPTION
This is a rebase of the Azure segments of #34 by @kppullin-nt against the latest codebase.

The original description follows.

***




TTL values must be recomputed on each `get` action instead of being fixed to a constant value for the lifetime of the cached object.

Prior to this change, the constant TTL value `X` would cause kafka-connect to continually reschedule connector restarts `X` milliseconds in the future, effectively ensuring that the connector never actually restarts.

With this change, the reschedule actions have a timestamp that shrinks until the TTL is reached.

Before (note contant restart time of ~30 mins):
```
2021-12-03 20:19:65,634 INFO   ||  Scheduling a restart of connector debezium_infra in 1799900 ms   [org.apache.kafka.connect.runtime.WorkerConfigTransformer]
2021-12-03 20:18:25,143 INFO   ||  Scheduling a restart of connector debezium_infra in 1799900 ms   [org.apache.kafka.connect.runtime.WorkerConfigTransformer]
```

After (note restart time decreases ~40 seconds and the log messages are ~40 seconds apart):
```
2021-12-03 21:09:24,228 INFO   ||  Scheduling a restart of connector debezium_infra in 2063263 ms   [org.apache.kafka.connect.runtime.WorkerConfigTransformer]
2021-12-03 21:08:45,858 INFO   ||  Scheduling a restart of connector debezium_infra in 2101945 ms   [org.apache.kafka.connect.runtime.WorkerConfigTransformer]
```

Fix build issues with Azure tests

Set the TTL to `None` if the duration is `0`