### PR TITLE
Allow leaving accessKey and secretKey undefined for DEFAULT auth mode.

### DIFF
--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSCredentials.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSCredentials.scala
@@ -1,0 +1,31 @@
+package io.lenses.connect.secrets.config
+
+import org.apache.kafka.common.config.types.Password
+import org.apache.kafka.connect.errors.ConnectException
+
+import scala.util.Try
+
+case class AWSCredentials(accessKey: String, secretKey: Password)
+
+object AWSCredentials {
+  def apply(configs: AWSProviderConfig): Either[Throwable, AWSCredentials] =
+    for {
+      accessKey <- Try(configs.getString(AWSProviderConfig.AWS_ACCESS_KEY)).toEither
+      secretKey <- Try(configs.getPassword(AWSProviderConfig.AWS_SECRET_KEY)).toEither
+
+      accessKeyValidated <- Either.cond(accessKey.nonEmpty,
+                                        accessKey,
+                                        new ConnectException(
+                                          s"${AWSProviderConfig.AWS_ACCESS_KEY} not set",
+                                        ),
+      )
+      secretKeyValidated <- Either.cond(secretKey.value().nonEmpty,
+                                        secretKey,
+                                        new ConnectException(
+                                          s"${AWSProviderConfig.AWS_SECRET_KEY} not set",
+                                        ),
+      )
+    } yield {
+      AWSCredentials(accessKeyValidated, secretKeyValidated)
+    }
+}

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderConfig.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/AWSProviderConfig.scala
@@ -33,14 +33,14 @@ object AWSProviderConfig {
       .define(
         AWS_ACCESS_KEY,
         Type.STRING,
-        null,
+        "",
         Importance.HIGH,
         "AWS access key",
       )
       .define(
         AWS_SECRET_KEY,
         Type.PASSWORD,
-        null,
+        "",
         Importance.HIGH,
         "AWS password key",
       )

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/AWSSecretProviderTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/AWSSecretProviderTest.scala
@@ -294,6 +294,21 @@ class AWSSecretProviderTest extends AnyWordSpec with Matchers with MockitoSugar 
     provider.close()
   }
 
+  "should allow default auth mode" in {
+
+    val provSettings = AWSProviderSettings(
+      AWSProviderConfig(
+        Map(
+          AWSProviderConfig.AWS_REGION  -> "someregion",
+          AWSProviderConfig.AUTH_METHOD -> AuthMode.DEFAULT.toString,
+        ).asJava,
+      ),
+    )
+
+    provSettings.authMode should be(AuthMode.DEFAULT)
+    provSettings.credentials should be(empty)
+  }
+
   "should throw an exception if access key not set and not default auth mode" in {
 
     intercept[ConnectException] {


### PR DESCRIPTION
As per #39 there is a bug in that accessKey and secretKey are expected even if using DEFAULT auth mode (in which key can come from the environment/profile etc).

This fixes the bug and adds a missing test.