### PR TITLE
Fix file encoding selection

### DIFF
--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/package.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/package.scala
@@ -51,6 +51,8 @@ package object connect extends StrictLogging {
     type Encoding = Value
     val BASE64, BASE64_FILE, UTF8, UTF8_FILE = Value
     def withNameOpt(s: String): Option[Value] = values.find(_.toString == s)
+
+    def withoutHyphensInsensitiveOpt(s: String): Option[Value] = withNameOpt(s.replace("-", "").toUpperCase)
   }
 
   // get the authmethod

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AzureHelper.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/AzureHelper.scala
@@ -37,9 +37,9 @@ trait AzureHelper extends StrictLogging {
         val value = secret.getValue
         val props = secret.getProperties
 
-        // check if the file-encoding
+        // check the file-encoding
         val encoding =
-          Encoding.withName(
+          Encoding.withoutHyphensInsensitiveOpt(
             Option(props.getTags)
               .map(_.getOrDefault(FILE_ENCODING, Encoding.UTF8.toString))
               .getOrElse(Encoding.UTF8.toString)

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/connect/EncodingTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/connect/EncodingTest.scala
@@ -1,0 +1,32 @@
+package io.lenses.connect.secrets.connect
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class EncodingTest extends AnyFunSuite with Matchers with TableDrivenPropertyChecks {
+
+  private val validEncodingsWithoutHyphens = Table(
+    ("input", "expectedResult"),
+    ("BASE64", Encoding.BASE64),
+    ("base64", Encoding.BASE64),
+    ("BASE-64", Encoding.BASE64),
+    ("BASE-64_FILE", Encoding.BASE64_FILE),
+    ("base64_file", Encoding.BASE64_FILE),
+    ("UTF8", Encoding.UTF8),
+    ("utf8", Encoding.UTF8),
+    ("UTF-8", Encoding.UTF8),
+    ("UTF-8_FILE", Encoding.UTF8_FILE),
+    ("utf8_file", Encoding.UTF8_FILE),
+  )
+
+  test("withoutHyphensInsensitiveOpt should recognize valid encodings") {
+    forAll(validEncodingsWithoutHyphens) { (input, expectedResult) =>
+      Encoding.withoutHyphensInsensitiveOpt(input) should be(Some(expectedResult))
+    }
+  }
+
+  test("withoutHyphensInsensitiveOpt should return None for an invalid input 'UNKNOWN-ENCODING'") {
+    Encoding.withoutHyphensInsensitiveOpt("UNKNOWN-ENCODING") should be(None)
+  }
+}


### PR DESCRIPTION
When using the file encoding tag from Azure, currently there is a mismatch between the file encodings defined in the project and those defined in Azure.  This makes it a little more lenient, stripping out the hyphen.