### PR TITLE
Support vault prefix depth config (#73)

### DIFF
--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/VaultProviderConfig.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/VaultProviderConfig.scala
@@ -34,6 +34,7 @@ object VaultProviderConfig {
   val VAULT_CLIENT_PEM: String = "vault.client.pem"
   val VAULT_PEM:        String = "vault.pem"
   val VAULT_ENGINE_VERSION = "vault.engine.version"
+  val VAULT_PREFIX_DEPTH   = "vault.prefix.depth"
   val AUTH_METHOD: String = "vault.auth.method"
 
   val VAULT_TRUSTSTORE_LOC: String =
@@ -146,6 +147,18 @@ object VaultProviderConfig {
       2,
       Importance.HIGH,
       "KV Secrets Engine version of the Vault server instance. Defaults to 2",
+    )
+    .define(
+      VAULT_PREFIX_DEPTH,
+      Type.INT,
+      1,
+      Importance.HIGH,
+      """
+        |Set the path depth of the KV Secrets Engine prefix path.
+        |Normally this is just 1, to correspond to one path element in the prefix path.
+        |To use a longer prefix path, set this value
+        |
+        |""".stripMargin,
     )
     // auth mode
     .define(

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/VaultProviderSettings.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/VaultProviderSettings.scala
@@ -50,6 +50,7 @@ case class VaultSettings(
   pem:            String,
   clientPem:      String,
   engineVersion:  Int = 2,
+  prefixDepth:    Int = 1,
   appRole:        Option[AppRole],
   awsIam:         Option[AwsIam],
   gcp:            Option[Gcp],
@@ -77,6 +78,7 @@ object VaultSettings extends StrictLogging {
     val pem           = config.getString(VaultProviderConfig.VAULT_PEM)
     val clientPem     = config.getString(VaultProviderConfig.VAULT_CLIENT_PEM)
     val engineVersion = config.getInt(VaultProviderConfig.VAULT_ENGINE_VERSION)
+    val prefixDepth   = config.getInt(VaultProviderConfig.VAULT_PREFIX_DEPTH)
 
     val authMode = VaultAuthMethod.withNameOpt(
       config.getString(VaultProviderConfig.AUTH_METHOD).toUpperCase,
@@ -124,6 +126,7 @@ object VaultSettings extends StrictLogging {
       pem            = pem,
       clientPem      = clientPem,
       engineVersion  = engineVersion,
+      prefixDepth    = prefixDepth,
       appRole        = appRole,
       awsIam         = awsIam,
       gcp            = gcp,

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/VaultHelper.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/VaultHelper.scala
@@ -110,6 +110,9 @@ object VaultHelper extends StrictLogging {
     logger.info(s"Setting engine version to ${settings.engineVersion}")
     config.engineVersion(settings.engineVersion)
 
+    logger.info(s"Setting prefix path depth to ${settings.prefixDepth}")
+    config.prefixPathDepth(settings.prefixDepth)
+
     val vault = new Vault(config.build())
 
     logger.info(

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/VaultSecretProviderTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/VaultSecretProviderTest.scala
@@ -324,6 +324,47 @@ class VaultSecretProviderTest extends AnyWordSpec with Matchers with BeforeAndAf
     response.getData.asScala("value") shouldBe "mock"
   }
 
+  "should be configured for vault engine prefix depth" in {
+
+    val props = Map(
+      VaultProviderConfig.VAULT_ADDR         -> "https://127.0.0.1:9998",
+      VaultProviderConfig.VAULT_TOKEN        -> "mock_token",
+      VaultProviderConfig.AUTH_METHOD        -> VaultAuthMethod.TOKEN.toString(),
+      VaultProviderConfig.VAULT_PEM          -> pemFile,
+      VaultProviderConfig.VAULT_CLIENT_PEM   -> pemFile,
+      VaultProviderConfig.VAULT_PREFIX_DEPTH -> 2,
+    ).asJava
+
+    val config   = VaultProviderConfig(props)
+    val settings = VaultSettings(config)
+
+    settings.prefixDepth shouldBe 2
+    val provider = new VaultSecretProvider()
+    provider.configure(props)
+    val response = provider.getClient.get.logical.read("secret/hello")
+    response.getData.asScala("value") shouldBe "mock"
+  }
+
+  "should be configured for default vault engine prefix depth" in {
+
+    val props = Map(
+      VaultProviderConfig.VAULT_ADDR         -> "https://127.0.0.1:9998",
+      VaultProviderConfig.VAULT_TOKEN        -> "mock_token",
+      VaultProviderConfig.AUTH_METHOD        -> VaultAuthMethod.TOKEN.toString(),
+      VaultProviderConfig.VAULT_PEM          -> pemFile,
+      VaultProviderConfig.VAULT_CLIENT_PEM   -> pemFile,
+    ).asJava
+
+    val config   = VaultProviderConfig(props)
+    val settings = VaultSettings(config)
+
+    settings.prefixDepth shouldBe 1
+    val provider = new VaultSecretProvider()
+    provider.configure(props)
+    val response = provider.getClient.get.logical.read("secret/hello")
+    response.getData.asScala("value") shouldBe "mock"
+  }
+
   "should get values at a path" in {
 
     val props = Map(


### PR DESCRIPTION
The Vault Secret Provider seems to have problems to retrieve secrets from KV secret engines with a path that is longer than one element (e.g. secrets/dev). This will make the prefix path depth of the vault client configurable. (#73)