### PR TITLE
Add env file support for ENVSecretProvider

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,6 +25,7 @@ trait Dependencies {
     val jettyVersion     = "11.0.14"
     val flexmarkVersion  = "0.64.0"
     val jsonSmartVersion = "2.5.0"
+    val dotenvVersion    = "3.0.0"
 
     val scalaCollectionCompatVersion = "2.8.1"
     val jakartaServletVersion        = "6.0.0"
@@ -76,7 +77,8 @@ trait Dependencies {
     val `json4sJackson` = "org.json4s"    %% "json4s-jackson" % json4sVersion
     val `cats`          = "org.typelevel" %% "cats-effect"    % catsEffectVersion
 
-    val `jsonSmart` = "net.minidev" % "json-smart" % jsonSmartVersion
+    val `jsonSmart` = "net.minidev"         % "json-smart"  % jsonSmartVersion
+    val `dotenv`    = "io.github.cdimascio" % "dotenv-java" % dotenvVersion
 
   }
 
@@ -84,6 +86,7 @@ trait Dependencies {
   val secretProviderDeps = Seq(
     `scala-logging`,
     `jsonSmart`,
+    `dotenv`,
     `kafka-connect-api` % Provided,
     `vault-java-driver`,
     `azure-key-vault` exclude ("net.minidev", "json-smart"),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -20,7 +20,7 @@ import java.nio.file.Paths
 
 object Settings extends Dependencies {
 
-  val scala213 = "2.13.10"
+  val scala213 = "2.13.18"
   val scala3   = "3.2.2"
 
   val nextVersion = "2.3.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.10.0

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/config/ENVProviderConfig.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/config/ENVProviderConfig.scala
@@ -16,12 +16,20 @@ import org.apache.kafka.common.config.ConfigDef
 import java.util
 
 object ENVProviderConfig {
+  val ENV_FILE: String = "env.file"
+
   val config = new ConfigDef().define(
     FILE_DIR,
     Type.STRING,
     "",
     Importance.MEDIUM,
     FILE_DIR_DESC,
+  ).define(
+    ENV_FILE,
+    Type.STRING,
+    "",
+    Importance.MEDIUM,
+    "Path to a .env file to load environment variables from. When set, only values from the file are used.",
   )
 }
 

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/ENVSecretProvider.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/ENVSecretProvider.scala
@@ -94,12 +94,20 @@ class ENVSecretProvider extends ConfigProvider {
           // the value metadata pattern
           envVarVal match {
             case BASE64_FILE(_, v) =>
+              if (fileDir.isEmpty)
+                throw new ConnectException(
+                  s"Failed to write [$key] to disk because file.dir is not set",
+                )
               //decode and write to file
               val fileName = s"$fileDir$separator${key.toLowerCase}"
               fileWriter(fileName, decodeToBytes(key, v), key)
               (key, fileName)
 
             case UTF8_FILE(_, v) =>
+              if (fileDir.isEmpty)
+                throw new ConnectException(
+                  s"Failed to write [$key] to disk because file.dir is not set",
+                )
               val fileName = s"$fileDir$separator${key.toLowerCase}"
               fileWriter(fileName, v.getBytes(), key)
               (key, fileName)

--- a/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/ENVSecretProvider.scala
+++ b/secret-provider/src/main/scala/io/lenses/connect/secrets/providers/ENVSecretProvider.scala
@@ -11,11 +11,15 @@ import io.lenses.connect.secrets.connect.FILE_DIR
 import io.lenses.connect.secrets.connect.decode
 import io.lenses.connect.secrets.connect.decodeToBytes
 import io.lenses.connect.secrets.connect.fileWriter
+import io.github.cdimascio.dotenv.Dotenv
 import org.apache.kafka.common.config.ConfigData
 import org.apache.kafka.common.config.provider.ConfigProvider
 import org.apache.kafka.connect.errors.ConnectException
 
 import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util
 import scala.jdk.CollectionConverters._
 
@@ -27,6 +31,49 @@ class ENVSecretProvider extends ConfigProvider {
   private val BASE64_FILE = "(ENV-mounted-base64:)(.*$)".r
   private val UTF8_FILE   = "(ENV-mounted:)(.*$)".r
   private val BASE64      = "(ENV-base64:)(.*$)".r
+
+  private def validatedEnvFilePath(path: String): Path = {
+    val normalized =
+      Option(path)
+        .map(_.trim)
+        .filter(_.nonEmpty)
+        .map(Paths.get(_).toAbsolutePath.normalize())
+        .getOrElse(throw new ConnectException("Configured env file path is empty"))
+
+    if (!Files.exists(normalized)) {
+      throw new ConnectException(s"Configured env file [$normalized] does not exist")
+    }
+
+    if (!Files.isRegularFile(normalized) || !Files.isReadable(normalized)) {
+      throw new ConnectException(s"Configured env file [$normalized] is not a readable regular file")
+    }
+
+    normalized
+  }
+
+  private def loadEnvFile(path: String): Map[String, String] = {
+    val filePath = validatedEnvFilePath(path)
+
+    val dir      = Option(filePath.getParent).map(_.toString).getOrElse(".")
+    val fileName = filePath.getFileName.toString
+
+    try {
+      val dotenv = Dotenv
+        .configure()
+        .directory(dir)
+        .filename(fileName)
+        .load()
+
+      dotenv
+        .entries(Dotenv.Filter.DECLARED_IN_ENV_FILE)
+        .asScala
+        .map(e => e.getKey -> e.getValue)
+        .toMap
+    } catch {
+      case exception: Exception =>
+        throw new ConnectException(s"Failed to read env file [$filePath]", exception)
+    }
+  }
 
   override def get(path: String): ConfigData =
     new ConfigData(Map.empty[String, String].asJava)
@@ -71,9 +118,10 @@ class ENVSecretProvider extends ConfigProvider {
   }
 
   override def configure(configs: util.Map[String, _]): Unit = {
-    vars = System.getenv().asScala.toMap
     val config = ENVProviderConfig(configs)
     fileDir = config.getString(FILE_DIR).stripSuffix(separator)
+    val envFile = config.getString(ENVProviderConfig.ENV_FILE).trim
+    vars = if (envFile.nonEmpty) loadEnvFile(envFile) else System.getenv().asScala.toMap
   }
 
   override def close(): Unit = {}

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/ENVSecretProviderTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/ENVSecretProviderTest.scala
@@ -120,4 +120,20 @@ class ENVSecretProviderTest extends AnyWordSpec with Matchers {
       provider.get("", Set("PATH").asJava)
     }
   }
+
+  "should throw when file.dir is not set for file-backed values" in {
+    val provider = new ENVSecretProvider()
+    provider.vars = Map(
+      "BASE64_FILE" -> s"ENV-mounted-base64:${Base64.getEncoder.encodeToString("my-base64-secret".getBytes)}",
+      "UTF8_FILE"   -> "ENV-mounted:my-secret",
+    )
+
+    intercept[ConnectException] {
+      provider.get("", Set("BASE64_FILE").asJava)
+    }
+
+    intercept[ConnectException] {
+      provider.get("", Set("UTF8_FILE").asJava)
+    }
+  }
 }

--- a/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/VaultSecretProviderTest.scala
+++ b/secret-provider/src/test/scala/io/lenses/connect/secrets/providers/VaultSecretProviderTest.scala
@@ -348,11 +348,11 @@ class VaultSecretProviderTest extends AnyWordSpec with Matchers with BeforeAndAf
   "should be configured for default vault engine prefix depth" in {
 
     val props = Map(
-      VaultProviderConfig.VAULT_ADDR         -> "https://127.0.0.1:9998",
-      VaultProviderConfig.VAULT_TOKEN        -> "mock_token",
-      VaultProviderConfig.AUTH_METHOD        -> VaultAuthMethod.TOKEN.toString(),
-      VaultProviderConfig.VAULT_PEM          -> pemFile,
-      VaultProviderConfig.VAULT_CLIENT_PEM   -> pemFile,
+      VaultProviderConfig.VAULT_ADDR       -> "https://127.0.0.1:9998",
+      VaultProviderConfig.VAULT_TOKEN      -> "mock_token",
+      VaultProviderConfig.AUTH_METHOD      -> VaultAuthMethod.TOKEN.toString(),
+      VaultProviderConfig.VAULT_PEM        -> pemFile,
+      VaultProviderConfig.VAULT_CLIENT_PEM -> pemFile,
     ).asJava
 
     val config   = VaultProviderConfig(props)


### PR DESCRIPTION
This PR adds env file support to the ENVSecretProvider. This allows to limit accessible environment variables to a .env file.
Process env variables will not be available if env file is configured.